### PR TITLE
Adding vertical scroll for job execution ids

### DIFF
--- a/ui/src/app/tasks-jobs/executions/execution/execution.component.html
+++ b/ui/src/app/tasks-jobs/executions/execution/execution.component.html
@@ -62,7 +62,7 @@
               </div>
               <div class="row">
                 <div class="key">Job Execution Ids</div>
-                <div class="value">
+                <div class="value-scroll">
                   {{execution.externalExecutionId || 'N/A'}}
                 </div>
               </div>

--- a/ui/src/app/tasks-jobs/jobs/execution/execution.component.html
+++ b/ui/src/app/tasks-jobs/jobs/execution/execution.component.html
@@ -163,7 +163,7 @@
               </div>
               <div class="row">
                 <div class="key">Job Execution Ids</div>
-                <div class="value">
+                <div class="value-scroll">
                   {{taskExecution.externalExecutionId || 'N/A'}}
                 </div>
               </div>

--- a/ui/src/app/tasks-jobs/jobs/step/step.component.html
+++ b/ui/src/app/tasks-jobs/jobs/step/step.component.html
@@ -307,7 +307,7 @@
               </div>
               <div class="row">
                 <div class="key">Job Execution Ids</div>
-                <div class="value">
+                <div class="value-scroll">
                   {{taskExecution.externalExecutionId || 'N/A'}}
                 </div>
               </div>

--- a/ui/src/app/tasks-jobs/tasks/task/task.component.html
+++ b/ui/src/app/tasks-jobs/tasks/task/task.component.html
@@ -108,7 +108,7 @@
               </div>
               <div class="row">
                 <div class="key">Job Execution Ids</div>
-                <div class="value">
+                <div class="value-scroll">
                   {{task.lastTaskExecution.externalExecutionId || 'N/A'}}
                 </div>
               </div>

--- a/ui/src/styles.scss
+++ b/ui/src/styles.scss
@@ -237,6 +237,11 @@ a:link, a:visited {
     .value {
       word-break: break-all;
     }
+
+    .value-scroll {
+      overflow-y: scroll;
+      height: 3rem;
+    }
   }
 
   &.lg-key {


### PR DESCRIPTION


- Adding a vertical scroll for Job Execution Ids.

-  Added a scroll bar for approximately 3 lines.

Fixes [#3957](https://github.com/spring-cloud/spring-cloud-dataflow/issues/3957)